### PR TITLE
get script name from module string; raise command exception

### DIFF
--- a/mmc/mixins.py
+++ b/mmc/mixins.py
@@ -32,7 +32,7 @@ class BaseCommandMixin(object):
         self._traceback = None
         self._show_traceback = False
         self._script = self.__module__.split('.')[-1]
-        self._lock = get_lock_instance()
+        self._lock = get_lock_instance(self._script)
 
     def __mmc_one_copy(self):
         try:


### PR DESCRIPTION
1. we lose the final script name without modifying sys.argv if using a wrapper to run commands.
   For example:
   ./manage.py maven rebuild_index --traceback

In this case "maven" is a script name as well as "rebuild_index", but MMC will store two log entries for the "maven" script instead of one log for each script.

https://github.com/saippuakauppias/django-maven
1. If command exception is not re-raised we lose it in our logs (sentry, for example)
